### PR TITLE
Add and Subtract Expressions tests - got rid of hardcoded datetime strings

### DIFF
--- a/src/test/TestCases.Activities/Expressions/Add.cs
+++ b/src/test/TestCases.Activities/Expressions/Add.cs
@@ -72,7 +72,9 @@ namespace Test.TestCases.Activities.Expressions
                 Right = new TimeSpan(17, 58, 59)
             };
 
-            TestSequence seq = TestExpressionTracer.GetTraceableBinaryExpressionActivity<DateTime, TimeSpan, DateTime>(add, @"2/12/2009 5:58:59 PM");
+            DateTime expectedDateTime = new DateTime(2009, 2, 12, 17, 58, 59);
+
+            TestSequence seq = TestExpressionTracer.GetTraceableBinaryExpressionActivity<DateTime, TimeSpan, DateTime>(add, expectedDateTime.ToString());
 
             TestRuntime.RunAndValidateWorkflow(seq);
         }

--- a/src/test/TestCases.Activities/Expressions/Subtract.cs
+++ b/src/test/TestCases.Activities/Expressions/Subtract.cs
@@ -128,7 +128,9 @@ namespace Test.TestCases.Activities.Expressions
                 Right = new TimeSpan(17, 58, 59)
             };
 
-            TestSequence seq = TestExpressionTracer.GetTraceableBinaryExpressionActivity<DateTime, TimeSpan, DateTime>(sub, @"2/11/2009 6:01:01 AM");
+            DateTime expectedDateTime = new DateTime(2009, 2, 11, 6, 1, 1);
+
+            TestSequence seq = TestExpressionTracer.GetTraceableBinaryExpressionActivity<DateTime, TimeSpan, DateTime>(sub, expectedDateTime.ToString());
 
             TestRuntime.RunAndValidateWorkflow(seq);
         }


### PR DESCRIPTION
Fixed Add and Subtract Expressions tests - got rid of hardcoded datetime strings.