### PR TITLE
Create nuget.config

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
  <configuration>
-    <config>
-        <add key="repositorypath" value="..\packages" />
-    </config>
-   
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />
     </activePackageSource>
@@ -11,6 +7,4 @@
 	<add key="dotnet.myget.org" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
-   <disabledPackageSources>
-   </disabledPackageSources>
  </configuration>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+ <configuration>
+    <config>
+        <add key="repositorypath" value="..\packages" />
+    </config>
+   
+    <activePackageSource>
+        <add key="All" value="(Aggregate source)" />
+    </activePackageSource>
+  <packageSources>
+	<add key="dotnet.myget.org" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+   <disabledPackageSources>
+   </disabledPackageSources>
+ </configuration>


### PR DESCRIPTION
The nuget.config allows to get the missing VisualBasic.Scripting package, see #49 