### PR TITLE
Allows resuming Wf at correct point after persistence

### DIFF
--- a/src/CoreWf/Bookmark.cs
+++ b/src/CoreWf/Bookmark.cs
@@ -10,9 +10,11 @@ namespace System.Activities
     using System.Runtime.Serialization;
     using System.Globalization;
     using System.Activities.Internals;
+    using System.ComponentModel;
 
     [DataContract]
     [Fx.Tag.XamlVisible(false)]
+    [TypeConverter(typeof(BookmarkConverter))]
     public class Bookmark : IEquatable<Bookmark>
     {
         private static readonly Bookmark asyncOperationCompletionBookmark = new Bookmark(-1);

--- a/src/CoreWf/BookmarkConverter.cs
+++ b/src/CoreWf/BookmarkConverter.cs
@@ -1,0 +1,34 @@
+﻿// This file is part of Core WF which is licensed under the MIT license.
+// See LICENSE file in the project root for full license information.
+
+namespace System.Activities
+{
+    using System;
+    using System.Globalization;
+    using System.ComponentModel;
+
+    public class BookmarkConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || sourceType == typeof(long); 
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+
+            if (value is string stringValue && !String.IsNullOrEmpty(stringValue))
+            {
+                return new Bookmark(stringValue);
+            }
+
+            if (value is long longValue && longValue != 0)
+            {
+                return Bookmark.Create(longValue);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+        
+    }
+}

--- a/src/CoreWf/Hosting/WorkflowInstance.cs
+++ b/src/CoreWf/Hosting/WorkflowInstance.cs
@@ -355,6 +355,8 @@ namespace System.Activities.Hosting
             this.executor.ThrowIfNonSerializable();
 
             EnsureDefinitionReady();
+
+            InitializeCore(null, null);
         }
 #endif
 

--- a/src/test/TestCases.Activities/Flowchart/Execution.cs
+++ b/src/test/TestCases.Activities/Flowchart/Execution.cs
@@ -534,7 +534,7 @@ namespace TestCases.Activities.Flowchart
         /// <summary>
         /// Unload and load flowchart while executing condition of flow conditional.
         /// </summary>        
-        [Fact(Skip = "Duplicate activities found in validation")]
+        [Fact()]
         public void UnloadFlowchartWhileExecutingFlowConditionalCondition()
         {
             TestFlowchart flowchart = new TestFlowchart();
@@ -578,7 +578,7 @@ namespace TestCases.Activities.Flowchart
         /// <summary>
         /// Unload and load flowchart while executing flow switch's expression.
         /// </summary>        
-        [Fact(Skip = "Duplicate activities found in validation")]
+        [Fact()]
         public void UnloadFlowchartWhileExecutingFlowSwitchExpression()
         {
             TestFlowchart flowchart = new TestFlowchart();
@@ -684,7 +684,7 @@ namespace TestCases.Activities.Flowchart
         /// <summary>
         /// Unload and load flowchart while executing flow step
         /// </summary>        
-        [Fact(Skip = "Duplicate activities found in validation")]
+        [Fact()]
         public void UnloadFlowchartWhileExecutingFlowStep()
         {
             TestFlowchart flowchart = new TestFlowchart();

--- a/src/test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
+++ b/src/test/TestCases.Runtime/WorflowInstanceResumeBookmarkAsyncTests.cs
@@ -297,7 +297,7 @@ namespace TestCases.Runtime.WorkflowInstanceTest
             }
         }
 
-        [Fact(Skip = "Test is flaky, fails after 60 seconds")]
+        [Fact()]
         public static void TestPersistDuringResumeBookmark()
         {
             bool isSync = true;

--- a/src/test/TestCases.Runtime/WorkflowInstanceAbortTests.cs
+++ b/src/test/TestCases.Runtime/WorkflowInstanceAbortTests.cs
@@ -193,7 +193,7 @@ namespace TestCases.Runtime.WorkflowInstanceTest
             runtime.WaitForAborted(out Exception excepion, expectedTrace);
         }
 
-        [Fact(Skip = "Test is flaky, fails after 60 seconds")]
+        [Fact()]
         public void TestAbortLoad()
         {
             Variable<int> value = VariableHelper.Create<int>("value");


### PR DESCRIPTION
Added InitializeCore(null, null) back into the codepath in WorkflowInstance

Thanks to @zehavibarak for the information on the missing InitializeCore.
This was part of the commented #if NET45 in the reload scenarios. (See comment // used for Load scenarios where you are rehydrating a WorkflowInstance).

Added a BookmarkConverter (new class, new file), so that we have less issues with the jsonstore.

This allows the following previously skipped tests to now pass:
UnloadFlowchartWhileExecutingFlowConditionalCondition
UnloadFlowchartWhileExecutingFlowSwitchExpression
UnloadFlowchartWhileExecutingFlowStep

The two tests which were flaky now seem to pass:
TestPersistDuringResumeBookmark
TestAbortLoad

These two tests are still timing dependent and always pass if run singly. They currently run on my RunAll.