### PR TITLE
WIP: Compile with roslyn through codedom provider

### DIFF
--- a/src/CoreWf/Microsoft/VisualBasic/Activities/HostedCompiler.cs
+++ b/src/CoreWf/Microsoft/VisualBasic/Activities/HostedCompiler.cs
@@ -2,7 +2,7 @@
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.CodeAnalysis.Scripting.Hosting;
 using Microsoft.CodeAnalysis.VisualBasic;
-using Microsoft.CodeAnalysis.VisualBasic.Scripting;
+//using Microsoft.CodeAnalysis.VisualBasic.Scripting;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using ReflectionMagic;
 using System;
@@ -16,6 +16,9 @@ namespace Microsoft.VisualBasic.Activities
     {
         public LambdaExpression CompileExpression(string expressionString, Func<string, Type> getVariableType, ScriptOptions options, Type lambdaReturnType = null)
         {
+            throw new NotImplementedException();
+        }
+            /*
             var untypedExpressionScript = VisualBasicScript.Create($"? {expressionString}", options);
             var identifiers = IdentifiersWalker.GetIdentifiers(untypedExpressionScript);
             var resolvedIdentifiers =
@@ -30,11 +33,12 @@ namespace Microsoft.VisualBasic.Activities
                 .Select(var => var.Type)
                 .Concat(new[] { lambdaReturnType ?? typeof(object) })
                 .Select(type => GetTypeName(type)));
-            var typedExpressionScript = 
+            var typedExpressionScript =
                 VisualBasicScript
                 .Create($"Dim resultExpression As Expression(Of Func(Of {types})) = Function({names}) ({expressionString})", options)
                 .ContinueWith("? resultExpression", options);
             return (LambdaExpression)typedExpressionScript.RunAsync().GetAwaiter().GetResult().ReturnValue;
+
         }
 
         class IdentifiersWalker : VisualBasicSyntaxWalker
@@ -79,12 +83,13 @@ namespace Microsoft.VisualBasic.Activities
 
             var args = new object[]
             {
-                0, /* arrayBoundRadix */
-                true /* showNamespaces */
+                0, // arrayBoundRadix
+                true // showNamespaces
             };
 
             TypeOptions = Activator.CreateInstance(type, args);
         }
+    */
 
         internal void Dispose()
         {

--- a/src/CoreWf/Microsoft/VisualBasic/Activities/VisualBasicValue.cs
+++ b/src/CoreWf/Microsoft/VisualBasic/Activities/VisualBasicValue.cs
@@ -55,12 +55,13 @@ namespace Microsoft.VisualBasic.Activities
         {
             get
             {
-                return false;
+                return true; //TODO: false;
             }
         }
 
         protected override TResult Execute(CodeActivityContext context)
         {
+            /*
             if (!this.invoker.IsStaticallyCompiled)
             {
                 if (this.expressionTree != null)
@@ -77,6 +78,7 @@ namespace Microsoft.VisualBasic.Activities
                 }
             }
             else
+            */
             {
                 return (TResult)this.invoker.InvokeExpression(context);
             }
@@ -86,6 +88,7 @@ namespace Microsoft.VisualBasic.Activities
         {
             this.expressionTree = null;
             this.invoker = new CompiledExpressionInvoker(this, false, metadata);
+            /*
             if (this.invoker.IsStaticallyCompiled == true)
             {
                 return;
@@ -93,7 +96,7 @@ namespace Microsoft.VisualBasic.Activities
 
             // If ICER is not implemented that means we haven't been compiled
 
-            CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);            
+            CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
             try
             {
                 this.expressionTree = VisualBasicHelper.Compile<TResult>(this.ExpressionText, publicAccessor, false);
@@ -102,11 +105,12 @@ namespace Microsoft.VisualBasic.Activities
             {
                 metadata.AddValidationError(e.Message);
             }
+            */
         }
 
         public bool CanConvertToString(IValueSerializerContext context)
         {
-            // we can always convert to a string 
+            // we can always convert to a string
             return true;
         }
 
@@ -117,7 +121,7 @@ namespace Microsoft.VisualBasic.Activities
         }
 
         public Expression GetExpressionTree()
-        {            
+        {
             if (this.IsMetadataCached)
             {
                 if (this.expressionTree == null)
@@ -127,17 +131,17 @@ namespace Microsoft.VisualBasic.Activities
                     CodeActivityMetadata metadata = new CodeActivityMetadata(this, this.GetParentEnvironment(), false);
                     CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
                     try
-                    {                                                
+                    {
                         this.expressionTree = VisualBasicHelper.Compile<TResult>(this.ExpressionText, publicAccessor, false);
                     }
                     catch (SourceExpressionException e)
                     {
-                        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.VBExpressionTamperedSinceLastCompiled(e.Message))); 
+                        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.VBExpressionTamperedSinceLastCompiled(e.Message)));
                     }
                     finally
                     {
                         metadata.Dispose();
-                    }                   
+                    }
                 }
 
                 Fx.Assert(this.expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
@@ -145,7 +149,7 @@ namespace Microsoft.VisualBasic.Activities
             }
             else
             {
-                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached)); 
+                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
             }
         }
     }

--- a/src/CoreWf/System.Activities.csproj
+++ b/src/CoreWf/System.Activities.csproj
@@ -33,7 +33,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Scripting" Version="2.8.0-dev-62823-01" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.8.0" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="3.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/CoreWf/XamlIntegration/ActivityXamlServices.cs
+++ b/src/CoreWf/XamlIntegration/ActivityXamlServices.cs
@@ -306,6 +306,47 @@ namespace System.Activities.XamlIntegration
                 ICompiledExpressionRoot compiledExpressionRoot = Activator.CreateInstance(compiledExpressionRootType, new object[] { dynamicActivity }) as ICompiledExpressionRoot;
                 CompiledExpressionInvoker.SetCompiledExpressionRootForImplementation(dynamicActivity, compiledExpressionRoot);
             }
+#else
+            string language = null;
+            if (RequiresCompilation(dynamicActivity, environment, out language))
+            {
+                TextExpressionCompiler compiler = new TextExpressionCompiler(GetCompilerSettings(dynamicActivity, language));
+                TextExpressionCompilerResults results = compiler.Compile();
+
+                if (results.HasErrors)
+                {
+                    var messages = new System.Text.StringBuilder();
+                    messages.Append("\r\n");
+                    messages.Append("\r\n");
+
+                    foreach (TextExpressionCompilerError message in results.CompilerMessages)
+                    {
+                        messages.Append("\t");
+                        if (results.HasSourceInfo)
+                        {
+                            messages.Append(string.Concat(" ", SR.ActivityXamlServiceLineString, " ", message.SourceLineNumber, ": "));
+                        }
+                        messages.Append(message.Message);
+
+                    }
+
+                    messages.Append("\r\n");
+                    messages.Append("\r\n");
+
+                    InvalidOperationException exception = new InvalidOperationException(SR.ActivityXamlServicesCompilationFailed(messages.ToString()));
+
+                    foreach (TextExpressionCompilerError message in results.CompilerMessages)
+                    {
+                        exception.Data.Add(message, message.Message);
+                    }
+                    throw FxTrace.Exception.AsError(exception);
+                }
+
+                Type compiledExpressionRootType = results.ResultType;
+
+                ICompiledExpressionRoot compiledExpressionRoot = Activator.CreateInstance(compiledExpressionRootType, new object[] { dynamicActivity }) as ICompiledExpressionRoot;
+                CompiledExpressionInvoker.SetCompiledExpressionRootForImplementation(dynamicActivity, compiledExpressionRoot);
+            }
 #endif
         }
 
@@ -353,12 +394,12 @@ namespace System.Activities.XamlIntegration
 
         private static TextExpressionCompilerSettings GetCompilerSettings(IDynamicActivity dynamicActivity, string language)
         {
-            int lastIndexOfDot = dynamicActivity.Name.LastIndexOf('.');
-            int lengthOfName = dynamicActivity.Name.Length;
+            var dynamicActivityName = dynamicActivity.Name ?? "DynamicActivity";
+            int lastIndexOfDot = dynamicActivityName.LastIndexOf('.');
 
-            string activityName = lastIndexOfDot > 0 ? dynamicActivity.Name.Substring(lastIndexOfDot + 1) : dynamicActivity.Name;
+            string activityName = lastIndexOfDot > 0 ? dynamicActivityName.Substring(lastIndexOfDot + 1) : dynamicActivityName;
             activityName += "_CompiledExpressionRoot";
-            string activityNamespace = lastIndexOfDot > 0 ? dynamicActivity.Name.Substring(0, lastIndexOfDot) : null;
+            string activityNamespace = lastIndexOfDot > 0 ? dynamicActivityName.Substring(0, lastIndexOfDot) : null;
 
             return new TextExpressionCompilerSettings()
             {

--- a/src/CoreWf/XamlIntegration/TextExpressionCompiler.cs
+++ b/src/CoreWf/XamlIntegration/TextExpressionCompiler.cs
@@ -2354,7 +2354,14 @@ namespace System.Activities.XamlIntegration
         {
             List<TextExpressionCompilerError> messages = new List<TextExpressionCompilerError>();
             CompilerParameters compilerParameters = GetCompilerParameters(messages);
-            
+
+#if !NET45
+            using (CodeDomProvider codeDomProvider = CodeDomProvider.CreateProvider(this.settings.Language))
+            {
+                return TextExpressionCompilerRoslyn.CompileWithRoslyn(this.settings.Language, this.compileUnit, codeDomProvider,
+                    compilerParameters, this.activityFullName);
+            }
+#else
             CompilerResults compilerResults = null;
             using (CodeDomProvider codeDomProvider = CodeDomProvider.CreateProvider(this.settings.Language))
             {
@@ -2404,6 +2411,7 @@ namespace System.Activities.XamlIntegration
             }
 
             return results;
+#endif
         }
 
         [Fx.Tag.SecurityNote(Critical = "Critical because we are using the CompilerParameters class, which has a link demand for Full Trust.",

--- a/src/CoreWf/XamlIntegration/TextExpressionCompilerRoslyn.cs
+++ b/src/CoreWf/XamlIntegration/TextExpressionCompilerRoslyn.cs
@@ -1,0 +1,116 @@
+using System.CodeDom;
+using System.CodeDom.Compiler;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.VisualBasic;
+
+namespace System.Activities.XamlIntegration
+{
+    internal class TextExpressionCompilerRoslyn
+    {
+        private static readonly MetadataReference NetStandardReference = MetadataReference.CreateFromFile(Assembly.Load("netstandard, Version=2.0.0.0").Location);
+        private static readonly MetadataReference SystemRuntimeReference = MetadataReference.CreateFromFile(Assembly.Load("System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a").Location);
+        private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
+        private static readonly MetadataReference SystemLinqReference = MetadataReference.CreateFromFile(typeof(Expression).Assembly.Location);
+        private static readonly MetadataReference SystemComponentModelReference = MetadataReference.CreateFromFile(typeof(BrowsableAttribute).Assembly.Location);
+        private static readonly MetadataReference SystemCodeDomReference = MetadataReference.CreateFromFile(typeof(GeneratedCodeAttribute).Assembly.Location);
+        private static readonly MetadataReference SystemActivitiesReference = MetadataReference.CreateFromFile(typeof(TextExpressionCompiler).Assembly.Location);
+        private static readonly MetadataReference VisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.CompilerServices.Operators).Assembly.Location);
+
+        internal static TextExpressionCompilerResults CompileWithRoslyn(string language, CodeCompileUnit compileUnit, CodeDomProvider codeDomProvider, CompilerParameters compilerParameters, string activityFullName)
+        {
+            var isVisualBasic = language == "VB";
+            var results = new TextExpressionCompilerResults();
+
+            var memoryStream = new MemoryStream();
+            using (var tw = new StreamWriter(memoryStream))
+            {
+                codeDomProvider.GenerateCodeFromCompileUnit(compileUnit, tw, new CodeGeneratorOptions());
+            }
+
+            var code = Encoding.UTF8.GetString(memoryStream.ToArray());
+            var syntaxTree = isVisualBasic ? VisualBasicSyntaxTree.ParseText(code) : CSharpSyntaxTree.ParseText(code);
+
+            // https://stackoverflow.com/questions/46421686/how-to-write-a-roslyn-analyzer-that-references-a-dotnet-standard-2-0-project
+            var references = new List<MetadataReference>()
+            {
+                NetStandardReference,
+                SystemRuntimeReference,
+                SystemReference,
+                SystemLinqReference,
+                SystemComponentModelReference,
+                SystemCodeDomReference,
+                SystemActivitiesReference
+            };
+
+            if (isVisualBasic)
+            {
+                references.Add(VisualBasicReference);
+            }
+
+            foreach (var r in compilerParameters.ReferencedAssemblies)
+            {
+                references.Add(MetadataReference.CreateFromFile(r));
+            }
+
+            Compilation compilation;
+
+            if (isVisualBasic)
+            {
+                compilation = VisualBasicCompilation.Create(
+                    "assemblyName",
+                    new[] { syntaxTree },
+                    references,
+                    new VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            }
+            else
+            {
+                compilation = CSharpCompilation.Create(
+                    "assemblyName",
+                    new[] { syntaxTree },
+                    references,
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            }
+
+            using (var dllStream = new MemoryStream())
+            using (var pdbStream = new MemoryStream())
+            {
+                var emitResult = compilation.Emit(dllStream, pdbStream);
+                if (!emitResult.Success)
+                {
+                    results.HasErrors = true;
+
+                    var errors = new List<TextExpressionCompilerError>();
+                    foreach (var diagnostic in emitResult.Diagnostics.Where(x => x.WarningLevel <= 1))
+                    {
+                        errors.Add(new TextExpressionCompilerError()
+                        {
+                            IsWarning = diagnostic.WarningLevel > 0,
+                            Message = diagnostic.GetMessage(),
+                            Number = diagnostic.Id,
+                            SourceLineNumber = diagnostic.Location.GetMappedLineSpan().StartLinePosition.Line
+                        });
+                    }
+
+                    results.SetMessages(errors, true);
+                }
+                else
+                {
+                    var assembly = Assembly.Load(dllStream.ToArray());
+
+                    results.HasErrors = false;
+                    results.ResultType = assembly.GetType(activityFullName);
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Test/Directory.Build.props
+++ b/src/Test/Directory.Build.props
@@ -5,7 +5,13 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
     <ProjectReference Include="..\..\CoreWf\System.Activities.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="..\..\System.Xaml\System.Xaml.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Test/TestCases.Workflows/XamlCSharpTests.cs
+++ b/src/Test/TestCases.Workflows/XamlCSharpTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Activities;
+using System.Activities.XamlIntegration;
+using System.Collections.Generic;
+using System.IO;
+using Shouldly;
+using Xunit;
+
+namespace TestCases.Workflows
+{
+    using IStringDictionary = IDictionary<string, object>;
+    using StringDictionary = Dictionary<string, object>;
+
+    public class XamlCSharpTests
+    {
+        [Fact]
+        public void XamlWorkflowCSharpValue()
+        {
+            var xamlString = @"
+                <Activity x:Class=""WFTemplate""
+                          xmlns=""http://schemas.microsoft.com/netfx/2009/xaml/activities""
+                          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+                          xmlns:mca=""clr-namespace:Microsoft.CSharp.Activities;assembly=System.Activities"">
+                    <x:Members>
+                        <x:Property Name=""myOutput"" Type=""OutArgument(x:Int32)"" />
+                        <x:Property Name=""myInput"" Type=""InArgument(x:Int32)"" />
+                    </x:Members>
+                    <Sequence>
+                        <Assign>
+                          <Assign.To>
+                            <OutArgument x:TypeArguments=""x:Int32"">
+                              <mca:CSharpReference x:TypeArguments=""x:Int32"">myOutput</mca:CSharpReference>
+                            </OutArgument>
+                          </Assign.To>
+                          <Assign.Value>
+                            <InArgument x:TypeArguments=""x:Int32"">
+                              <mca:CSharpValue x:TypeArguments=""x:Int32"">myInput</mca:CSharpValue>
+                            </InArgument>
+                          </Assign.Value>
+                        </Assign>
+                        <WriteLine>
+                          <InArgument x:TypeArguments=""x:String"">
+                            <mca:CSharpValue x:TypeArguments=""x:String"">myOutput.ToString()</mca:CSharpValue>
+                          </InArgument>
+                        </WriteLine>
+                    </Sequence>
+                </Activity>";
+
+            var inputs = new StringDictionary { ["myInput"] = 5 };
+            var outputs = InvokeWorkflow(xamlString, inputs);
+            outputs.Count.ShouldBe(1);
+            outputs.ContainsKey("myOutput").ShouldBeTrue();
+            outputs["myOutput"].ShouldBe(5);
+        }
+
+        [Fact]
+        public void XamlWorkflowCSharpValueCompilerError()
+        {
+            var xamlString = @"
+                <Activity x:Class=""WFTemplate""
+                          xmlns=""http://schemas.microsoft.com/netfx/2009/xaml/activities""
+                          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+                          xmlns:mca=""clr-namespace:Microsoft.CSharp.Activities;assembly=System.Activities"">
+                    <Sequence>
+                        <WriteLine>
+                          <InArgument x:TypeArguments=""x:String"">
+                            <mca:CSharpValue x:TypeArguments=""x:String"">myOutput.ToString()</mca:CSharpValue>
+                          </InArgument>
+                        </WriteLine>
+                    </Sequence>
+                </Activity>";
+
+            try
+            {
+                var outputs = InvokeWorkflow(xamlString);
+                outputs.ShouldBeNull("Compilation should throw an exception");
+            }
+            catch (Exception e)
+            {
+                e.Message.ShouldStartWith("Compilation failures occurred");
+                e.Message.ShouldContain("The name 'myOutput' does not exist in the current context");
+            }
+        }
+
+        private static IStringDictionary InvokeWorkflow(string xamlString, IStringDictionary inputs = null)
+        {
+            var activity = ActivityXamlServices.Load(new StringReader(xamlString), new ActivityXamlServicesSettings { CompileExpressions = true });
+            return WorkflowInvoker.Invoke(activity, inputs ?? new StringDictionary());
+        }
+    }
+}

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -156,8 +156,14 @@ namespace TestCases.Workflows
                               xmlns:s=""clr-namespace:System;assembly=mscorlib""
                               xmlns:s1=""clr-namespace:System;assembly=System""
                               xmlns:sa=""clr-namespace:System.Activities;assembly=System.Activities""
+                              xmlns:sco=""clr-namespace:System.Collections.ObjectModel;assembly=mscorlib""
                               xmlns:hw=""clr-namespace:TestCases.Workflows;assembly=TestCases.Workflows""
                               xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml"">
+                        <TextExpression.ReferencesForImplementation>
+                            <sco:Collection x:TypeArguments=""AssemblyReference"">
+                               <AssemblyReference>TestCases.Workflows</AssemblyReference>
+                            </sco:Collection>
+                        </TextExpression.ReferencesForImplementation>
                         <x:Members>
                             <x:Property Name=""myInput"" Type=""InArgument(hw:PersonToGreet)"" />
                         </x:Members>


### PR DESCRIPTION
This is an experiment of mine to get CSharpValue and CSharpReference up and running to fix #48 

It still uses the code dom provider to generate the code, but then passes that code to the roslyn compiler for compilation.

Unfortunately I was not able to find a good combination of the packages together with the VB scripting prerelease version, so I also converted the VB value + reference so that they always require compilation.

For my project that would be good enough, we anyway only use it that way.

Tests seem to pass that far, unfortunately cannot try it on linux as System.Activities is not compilable there (becuase of the desktop sdk).

Please let me know if you have some ideas/proposals.