### PR TITLE
Consolidate CSharpValue and CSharpReference + fix some compiler issues

### DIFF
--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -1,20 +1,21 @@
 ﻿// This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.CSharp.Activities;
+using Microsoft.VisualBasic.Activities;
 using System.Activities.ExpressionParser;
 using System.Activities.Expressions;
+using System.Activities.Internals;
+using System.Activities.Runtime;
 using System.CodeDom;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Activities.Runtime;
 using System.Runtime.Collections;
-using System.Threading;
-using System.Collections.ObjectModel;
 using System.Security;
-using System.Activities.Internals;
-using Microsoft.VisualBasic.Activities;
-using System.Linq;
+using System.Threading;
 
 namespace System.Activities
 {
@@ -1385,7 +1386,7 @@ namespace System.Activities
                 {
                     try
                     {
-                        lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable, typeof(object)));
+                        lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable, typeof(object), true));
                     }
                     catch(Exception e)
                     {
@@ -1426,8 +1427,8 @@ namespace System.Activities
             return Expression.Lambda(finalBody, lambda.Parameters);
         }
 
-        ExpressionToCompile ExpressionToCompile(Func<string, Type> variableTypeGetter, Type lambdaReturnType) => 
-            new ExpressionToCompile(TextToCompile, namespaceImports)
+        ExpressionToCompile ExpressionToCompile(Func<string, Type> variableTypeGetter, Type lambdaReturnType, bool useConversion) => 
+            new ExpressionToCompile(TextToCompile, namespaceImports, useConversion)
             {
                 VariableTypeGetter = variableTypeGetter,
                 LambdaReturnType = lambdaReturnType,
@@ -1525,7 +1526,7 @@ namespace System.Activities
                 {
                     try
                     {
-                        lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable, lambdaReturnType));
+                        lambda = compiler.CompileExpression(ExpressionToCompile(scriptAndTypeScope.FindVariable, lambdaReturnType, false));
                     }
                     catch(Exception e)
                     {

--- a/src/UiPath.Workflow/AssemblyInfo.cs
+++ b/src/UiPath.Workflow/AssemblyInfo.cs
@@ -22,3 +22,4 @@ using System.Windows.Markup;
 
 [assembly: XmlnsDefinition("http://schemas.microsoft.com/netfx/2010/xaml/activities/debugger", "System.Activities.Debugger.Symbol")]
 [assembly: XmlnsPrefix("http://schemas.microsoft.com/netfx/2010/xaml/activities/debugger", "sads")]
+[assembly: InternalsVisibleTo("TestCases.Workflows")]

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpReference.cs
@@ -1,80 +1,36 @@
 ﻿// This file is part of Core WF which is licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
+using Microsoft.Common;
 using System;
 using System.Activities;
-using System.Activities.Expressions;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Windows.Markup;
-using System.Activities.Internals;
 
 namespace Microsoft.CSharp.Activities
 {
-    [DebuggerStepThrough]
-    [ContentProperty("ExpressionText")]
-    public class CSharpReference<TResult> : CodeActivity<Location<TResult>>, ITextExpression
+    [System.Diagnostics.DebuggerStepThrough]
+    [System.Windows.Markup.ContentProperty("ExpressionText")]
+    public class CSharpReference<TResult> : Reference<TResult>
     {
-        CompiledExpressionInvoker invoker;
-                
         public CSharpReference()
         {
             this.UseOldFastPath = true;
         }
 
-        public CSharpReference(string expressionText) :
-            this()
-        {
-            this.ExpressionText = expressionText;
-        }
-
-        public string ExpressionText
-        {
-            get;
-            set;
-        }
+        public CSharpReference(string expressionText) : base(expressionText) { }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string Language
+        public override string Language
         {
             get
             {
-                return "C#";
+                return CSharpHelper.Language;
             }
         }
 
-        public bool RequiresCompilation
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override void CacheMetadata(CodeActivityMetadata metadata)
-        {
-            this.invoker = new CompiledExpressionInvoker(this, true, metadata);
-        }
-
-        protected override Location<TResult> Execute(CodeActivityContext context)
-        {
-            Location<TResult> value = (Location<TResult>)this.invoker.InvokeExpression(context);
-
-            return value;
-        }
-
-        public Expression GetExpressionTree()
-        {
-            if (this.IsMetadataCached)
-            {
-                return this.invoker.GetExpressionTree();
-            }
-            else
-            {
-                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached)); 
-            }
-        }
+        protected override Expression<Func<ActivityContext, T>> Compile<T>(string expressionText, CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression)
+            => CSharpHelper.Compile<T>(expressionText, publicAccessor, isLocationExpression);
     }
 }
 

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpValue.cs
@@ -3,79 +3,33 @@
 
 namespace Microsoft.CSharp.Activities
 {
+    using Microsoft.Common;
     using System;
     using System.Activities;
-    using System.Activities.Expressions;
-    using System.Activities.Validation;
-    using System.Activities.XamlIntegration;
-    using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Diagnostics;
     using System.Linq.Expressions;
-    using System.Reflection;
-    using System.Activities.Runtime;
     using System.Windows.Markup;
-    using System.Activities.Internals;
 
-    [DebuggerStepThrough]
+    [System.Diagnostics.DebuggerStepThrough]
     [ContentProperty("ExpressionText")]
-    public class CSharpValue<TResult> : CodeActivity<TResult>, ITextExpression
+    public class CSharpValue<TResult> : Value<TResult>
     {
-        CompiledExpressionInvoker invoker;
-          
         public CSharpValue()
         {
             this.UseOldFastPath = true;
         }
 
-        public CSharpValue(string expressionText) :
-            this()
-        {
-            this.ExpressionText = expressionText;
-        }
+        public CSharpValue(string expressionText) : base(expressionText) { }
 
-        public string ExpressionText
-        {
-            get;
-            set;
-        }
+        protected override Expression<Func<ActivityContext, T>> Compile<T>(string expressionText, CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression)
+            => CSharpHelper.Compile<T>(expressionText, publicAccessor, isLocationExpression);
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string Language
+        public override string Language
         {
             get
             {
-                return "C#";
-            }
-        }
-
-        public bool RequiresCompilation
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        protected override void CacheMetadata(CodeActivityMetadata metadata)
-        {
-            this.invoker = new CompiledExpressionInvoker(this, false, metadata);
-        }
-
-        protected override TResult Execute(CodeActivityContext context)
-        {
-            return (TResult)this.invoker.InvokeExpression(context);
-        }
-
-        public Expression GetExpressionTree()
-        {
-            if (this.IsMetadataCached)
-            {
-                return this.invoker.GetExpressionTree();
-            }
-            else
-            {
-                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+                return CSharpHelper.Language;
             }
         }
     }

--- a/src/UiPath.Workflow/Microsoft/Common/Reference.cs
+++ b/src/UiPath.Workflow/Microsoft/Common/Reference.cs
@@ -1,0 +1,129 @@
+﻿
+namespace Microsoft.Common
+{
+    using System;
+    using System.Activities;
+    using System.Activities.ExpressionParser;
+    using System.Activities.Expressions;
+    using System.Activities.Internals;
+    using System.Activities.Runtime;
+    using System.Linq.Expressions;
+
+    public abstract class Reference<TResult> : CodeActivity<Location<TResult>>, IExpressionContainer, ITextExpression
+    {
+        private Expression<Func<ActivityContext, TResult>> expressionTree;
+        private LocationFactory<TResult> locationFactory;
+        private CompiledExpressionInvoker invoker;
+
+        public string ExpressionText { get; set; }
+
+        public abstract string Language { get; }
+
+        public bool RequiresCompilation => true;
+
+        protected Reference() { }
+
+        protected Reference(string expressionText)
+        {
+            this.ExpressionText = expressionText;
+        }
+
+        protected override Location<TResult> Execute(CodeActivityContext context)
+        {
+            if (expressionTree == null)
+            {
+                return (Location<TResult>)invoker.InvokeExpression(context);
+            }
+            if (locationFactory == null)
+            {
+                locationFactory = ExpressionUtilities.CreateLocationFactory<TResult>(this.expressionTree);
+            }
+            return locationFactory.CreateLocation(context);
+        }
+
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            expressionTree = null;
+            invoker = new CompiledExpressionInvoker(this, true, metadata);
+            if (metadata.Environment.CompileExpressions)
+            {
+                return;
+            }
+            string validationError;
+            // If ICER is not implemented that means we haven't been compiled
+            var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
+            expressionTree = CompileLocationExpression(publicAccessor, out validationError);
+            if (validationError != null)
+            {
+                metadata.AddValidationError(validationError);
+            }
+        }
+
+        public Expression GetExpressionTree()
+        {
+            if (this.IsMetadataCached)
+            {
+                if (this.expressionTree == null)
+                {
+                    string validationError;
+
+                    // it's safe to create this CodeActivityMetadata here,
+                    // because we know we are using it only as lookup purpose.
+                    CodeActivityMetadata metadata = new CodeActivityMetadata(this, this.GetParentEnvironment(), false);
+                    CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
+                    try
+                    {
+                        this.expressionTree = this.CompileLocationExpression(publicAccessor, out validationError);
+
+                        if (validationError != null)
+                        {
+                            throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(validationError)));
+                        }
+                    }
+                    finally
+                    {
+                        metadata.Dispose();
+                    }
+                }
+
+                Fx.Assert(this.expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
+                return ExpressionUtilities.RewriteNonCompiledExpressionTree(expressionTree);
+            }
+            else
+            {
+                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+            }
+        }
+
+        protected abstract Expression<Func<ActivityContext, T>> Compile<T>(string expressionText, CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression);
+
+        private Expression<Func<ActivityContext, TResult>> CompileLocationExpression(CodeActivityPublicEnvironmentAccessor publicAccessor, out string validationError)
+        {
+            Expression<Func<ActivityContext, TResult>> expressionTreeToReturn = null;
+            validationError = null;
+            try
+            {
+                expressionTreeToReturn = Compile<TResult>(this.ExpressionText, publicAccessor, true);
+                // inspect the expressionTree to see if it is a valid location expression(L-value)
+                string extraErrorMessage = null;
+                if (!publicAccessor.ActivityMetadata.HasViolations && (expressionTreeToReturn == null || !ExpressionUtilities.IsLocation(expressionTreeToReturn, typeof(TResult), out extraErrorMessage)))
+                {
+                    string errorMessage = SR.InvalidLValueExpression;
+
+                    if (extraErrorMessage != null)
+                    {
+                        errorMessage += ":" + extraErrorMessage;
+                    }
+                    expressionTreeToReturn = null;
+                    validationError = SR.CompilerErrorSpecificExpression(this.ExpressionText, errorMessage);
+                }
+            }
+            catch (SourceExpressionException e)
+            {
+                validationError = e.Message;
+            }
+
+            return expressionTreeToReturn;
+        }
+    }
+}

--- a/src/UiPath.Workflow/Microsoft/Common/Value.cs
+++ b/src/UiPath.Workflow/Microsoft/Common/Value.cs
@@ -1,0 +1,99 @@
+﻿
+namespace Microsoft.Common
+{
+    using System;
+    using System.Activities;
+    using System.Activities.ExpressionParser;
+    using System.Activities.Expressions;
+    using System.Activities.Internals;
+    using System.Activities.Runtime;
+    using System.Linq.Expressions;
+
+    public abstract class Value<TResult> : CodeActivity<TResult>, IExpressionContainer, ITextExpression
+    {
+        private Expression<Func<ActivityContext, TResult>> expressionTree;
+        private Func<ActivityContext, TResult> compiledExpression;
+        private CompiledExpressionInvoker invoker;
+
+        public string ExpressionText { get; set; }
+
+        public abstract string Language { get; }
+
+        public bool RequiresCompilation => true;
+
+        protected Value() { }
+
+        protected Value(string expressionText)
+        {
+            this.ExpressionText = expressionText;
+        }
+
+        public Expression GetExpressionTree()
+        {
+            if (this.IsMetadataCached)
+            {
+                if (this.expressionTree == null)
+                {
+                    // it's safe to create this CodeActivityMetadata here,
+                    // because we know we are using it only as lookup purpose.
+                    CodeActivityMetadata metadata = new CodeActivityMetadata(this, this.GetParentEnvironment(), false);
+                    CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
+                    try
+                    {
+                        expressionTree = Compile<TResult>(this.ExpressionText, publicAccessor, false);
+                    }
+                    catch (SourceExpressionException e)
+                    {
+                        throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(e.Message)));
+                    }
+                    finally
+                    {
+                        metadata.Dispose();
+                    }
+                }
+
+                Fx.Assert(this.expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
+                return ExpressionUtilities.RewriteNonCompiledExpressionTree(expressionTree);
+            }
+            else
+            {
+                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
+            }
+        }
+
+        protected abstract Expression<Func<ActivityContext, T>> Compile<T>(string expressionText, CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression);
+
+        protected override TResult Execute(CodeActivityContext context)
+        {
+            if (expressionTree == null)
+            {
+                return (TResult)invoker.InvokeExpression(context);
+            }
+            if (compiledExpression == null)
+            {
+                compiledExpression = expressionTree.Compile();
+            }
+            return compiledExpression(context);
+        }
+
+        protected override void CacheMetadata(CodeActivityMetadata metadata)
+        {
+            expressionTree = null;
+            invoker = new CompiledExpressionInvoker(this, false, metadata);
+            if (metadata.Environment.CompileExpressions)
+            {
+                return;
+            }
+            // If ICER is not implemented that means we haven't been compiled
+            var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
+            try
+            {
+                expressionTree = Compile<TResult>(this.ExpressionText, publicAccessor, false);
+            }
+            catch (SourceExpressionException e)
+            {
+                metadata.AddValidationError(e.Message);
+            }
+        }
+    }
+}

--- a/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicReference.cs
+++ b/src/UiPath.Workflow/Microsoft/VisualBasic/Activities/VisualBasicReference.cs
@@ -3,45 +3,26 @@
 
 namespace Microsoft.VisualBasic.Activities
 {
+    using Microsoft.Common;
     using System;
-    using System.Collections.Generic;
     using System.Activities;
-    using System.Activities.Expressions;
-    using System.Activities.ExpressionParser;
     using System.Activities.XamlIntegration;
+    using System.ComponentModel;
     using System.Linq.Expressions;
     using System.Windows.Markup;
-    using System.ComponentModel;
-    using System.Activities.Runtime;
-    using System.Activities.Internals;
 
     [System.Diagnostics.DebuggerStepThrough]
-    public sealed class VisualBasicReference<TResult> : CodeActivity<Location<TResult>>, IValueSerializableExpression, IExpressionContainer, ITextExpression
+    public sealed class VisualBasicReference<TResult> : Reference<TResult>, IValueSerializableExpression
     {
-        Expression<Func<ActivityContext, TResult>> expressionTree;
-        LocationFactory<TResult> locationFactory;
-        CompiledExpressionInvoker invoker;
-
-        public VisualBasicReference() 
-            : base()
+        public VisualBasicReference()
         {
             this.UseOldFastPath = true;
         }
 
-        public VisualBasicReference(string expressionText)
-            : this()
-        {
-            this.ExpressionText = expressionText;
-        }
-
-        public string ExpressionText
-        {
-            get;
-            set;
-        }
+        public VisualBasicReference(string expressionText) : base(expressionText) { }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string Language
+        public override string Language
         {
             get
             {
@@ -49,44 +30,10 @@ namespace Microsoft.VisualBasic.Activities
             }
         }
 
-        public bool RequiresCompilation
-        {
-            get
-            {
-                return true;
-            }
-        }
+        protected override Expression<Func<ActivityContext, T>> Compile<T>(string expressionText, CodeActivityPublicEnvironmentAccessor publicAccessor, bool isLocationExpression)
+            => VisualBasicHelper.Compile<T>(expressionText, publicAccessor, isLocationExpression);
 
-        protected override Location<TResult> Execute(CodeActivityContext context)
-        {
-            if (expressionTree == null)
-            {
-                return (Location<TResult>)invoker.InvokeExpression(context);
-            }
-            if (locationFactory == null)
-            {
-                locationFactory = ExpressionUtilities.CreateLocationFactory<TResult>(this.expressionTree);
-            }
-            return locationFactory.CreateLocation(context);
-        }
-
-        protected override void CacheMetadata(CodeActivityMetadata metadata)
-        {
-            expressionTree = null;
-            invoker = new CompiledExpressionInvoker(this, true, metadata);
-            if (metadata.Environment.CompileExpressions)
-            {
-                return;
-            }
-            string validationError;
-            // If ICER is not implemented that means we haven't been compiled
-            var publicAccessor = CodeActivityPublicEnvironmentAccessor.Create(metadata);
-            expressionTree = CompileLocationExpression(publicAccessor, out validationError);
-            if (validationError != null)
-            {
-                metadata.AddValidationError(validationError);
-            }
-        }
+        #region IValueSerializableExpression
 
         public bool CanConvertToString(IValueSerializerContext context)
         {
@@ -100,69 +47,6 @@ namespace Microsoft.VisualBasic.Activities
             return "[" + this.ExpressionText + "]";
         }
 
-        public Expression GetExpressionTree()
-        {
-            if (this.IsMetadataCached)
-            {
-                if (this.expressionTree == null)
-                {
-                    string validationError;
-
-                    // it's safe to create this CodeActivityMetadata here,
-                    // because we know we are using it only as lookup purpose.
-                    CodeActivityMetadata metadata = new CodeActivityMetadata(this, this.GetParentEnvironment(), false);
-                    CodeActivityPublicEnvironmentAccessor publicAccessor = CodeActivityPublicEnvironmentAccessor.CreateWithoutArgument(metadata);
-                    try
-                    {
-                        this.expressionTree = this.CompileLocationExpression(publicAccessor, out validationError);
-
-                        if (validationError != null)
-                        {
-                            throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ExpressionTamperedSinceLastCompiled(validationError)));
-                        }            
-                    }
-                    finally
-                    {
-                        metadata.Dispose();
-                    }                    
-                }
-
-                Fx.Assert(this.expressionTree.NodeType == ExpressionType.Lambda, "Lambda expression required");
-                return ExpressionUtilities.RewriteNonCompiledExpressionTree((LambdaExpression)this.expressionTree);
-            }
-            else
-            {
-                throw FxTrace.Exception.AsError(new InvalidOperationException(SR.ActivityIsUncached));
-            }
-        }
-
-        private Expression<Func<ActivityContext, TResult>> CompileLocationExpression(CodeActivityPublicEnvironmentAccessor publicAccessor, out string validationError)
-        {            
-            Expression<Func<ActivityContext, TResult>> expressionTreeToReturn = null;
-            validationError = null;
-            try
-            {
-                expressionTreeToReturn = VisualBasicHelper.Compile<TResult>(this.ExpressionText, publicAccessor, true);
-                // inspect the expressionTree to see if it is a valid location expression(L-value)
-                string extraErrorMessage = null;
-                if (!publicAccessor.ActivityMetadata.HasViolations && (expressionTreeToReturn == null || !ExpressionUtilities.IsLocation(expressionTreeToReturn, typeof(TResult), out extraErrorMessage)))
-                {
-                    string errorMessage = SR.InvalidLValueExpression;
-
-                    if (extraErrorMessage != null)
-                    {
-                        errorMessage += ":" + extraErrorMessage;
-                    }
-                    expressionTreeToReturn = null;
-                    validationError = SR.CompilerErrorSpecificExpression(this.ExpressionText, errorMessage);
-                }
-            }
-            catch (SourceExpressionException e)
-            {
-                validationError = e.Message;
-            }
-
-            return expressionTreeToReturn;
-        }
+        #endregion IValueSerializableExpression
     }
 }


### PR DESCRIPTION
CSharpValue and CSharpReference are now consolidated and use the same cache metadata methods as their visual basic counterparts. This was done for 2 reasons:
- to behave the same for both languages
- there was an issue that a workflow with errors, that was closed, when opening, it had no errors. This was due to fact that when opening a workflow, an error caused by the compilation of an expression will not trigger the error icon on the activity, but rather the second compilation, which was triggered by the CacheMetadata from CSharpValue and CSharpReference was also updating the error icons.

Also, the JitCompilerHelper was acting inconsistently on C# and VB example provided below:
- vb compilation template does not contain an explicit conversion, while C# does (see `CreateExpressionCode` overrides). This caused in certain scenarios for VB to have an explicit conversion by default, when called from method `CompileNonGeneric`, which set the return type to object (this caused a lambda like `() => Convert("abc", typeof(object))`). But C# will always have that conversion, not just "sometimes", which causes the problem below.
- The other call to compile, which is causing the problem is from JitCompilerHelper's method `Compile<T>(LocationReferenceEnvironment environment, bool isLocationReference)`. This is called for compiling references, that could look like this: `(variable1) => variable1;`. The problem is that for VB, this does not contain a conversion, but for C# we still force it due to above template, and we ended up with `(variable1) => Convert(variable1, typeof(given_type));`. This was causing an error on the designer stating "Reference expression cannot end with conversion", which was only occurring on C#, because of the forced conversion. This is further persisted wrong in the rawTreeCache, with the unwanted conversion.

For this matter, we no got an explicit boolean `useConversion` that states when we will force a conversion, and when we will not, giving us expected results.
There are unit tests to validate that everything works as expected for the new implementation.