### PR TITLE
Set VB compilation Option Strict On

### DIFF
--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using Microsoft.CSharp.Activities;
 using Microsoft.VisualBasic.Activities;
 using Newtonsoft.Json;
@@ -238,9 +239,12 @@ namespace TestCases.Workflows
         // VB should be Strict On, not to allow implicit conversions such as from int to string
         public void Should_Fail_VBConversion()
         {
-            var compiler = new VbJitCompiler(new[] { typeof(int).Assembly, typeof(Expression).Assembly }.ToHashSet());
-            Assert.Throws<SourceExpressionException>(() => compiler.CompileExpression(new ExpressionToCompile("1", new[] { "System", "System.Linq", "System.Linq.Expressions" },
+            var compiler = new VbJitCompiler(new[] { typeof(int).Assembly, typeof(Expression).Assembly, Assembly.Load("Microsoft.VisualBasic.Core") }.ToHashSet());
+            var exception = Record.Exception(() => compiler.CompileExpression(new ExpressionToCompile("1", new[] { "System", "System.Linq", "System.Linq.Expressions" },
                 _ => typeof(int), typeof(string))));
+
+            exception.ShouldBeOfType<SourceExpressionException>();
+            exception.Message.ShouldContain("BC30512: Option Strict On disallows implicit conversions");
         }
     }
     public class AheadOfTimeXamlTests : XamlTestsBase

--- a/src/Test/TestCases.Workflows/XamlTests.cs
+++ b/src/Test/TestCases.Workflows/XamlTests.cs
@@ -233,6 +233,15 @@ namespace TestCases.Workflows
                 name => name == "source" ? typeof(List<int>) : null, typeof(int)));
             ((Func<List<int>, int>)result.Compile())(new List<int> { 1, 2, 3 }).ShouldBe(6);
         }
+
+        [Fact]
+        // VB should be Strict On, not to allow implicit conversions such as from int to string
+        public void Should_Fail_VBConversion()
+        {
+            var compiler = new VbJitCompiler(new[] { typeof(int).Assembly, typeof(Expression).Assembly }.ToHashSet());
+            Assert.Throws<SourceExpressionException>(() => compiler.CompileExpression(new ExpressionToCompile("1", new[] { "System", "System.Linq", "System.Linq.Expressions" },
+                _ => typeof(int), typeof(string))));
+        }
     }
     public class AheadOfTimeXamlTests : XamlTestsBase
     {

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -88,7 +88,7 @@ namespace System.Activities
         protected override Script<object> Create(string code, ScriptOptions options) => VisualBasicScript.Create("? "+code, options);
         protected override string GetTypeName(Type type) => VisualBasicObjectFormatter.FormatTypeName(type);
         protected override string CreateExpressionCode(string types, string names, string code) =>
-             $"Option Strict On\nPublic Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+             $"Public Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
         protected override int IdentifierKind => (int)Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.IdentifierName;
     }
     public class CSharpJitCompiler : ScriptingJitCompiler

--- a/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
+++ b/src/UiPath.Workflow/Activities/ScriptingJitCompiler.cs
@@ -88,7 +88,7 @@ namespace System.Activities
         protected override Script<object> Create(string code, ScriptOptions options) => VisualBasicScript.Create("? "+code, options);
         protected override string GetTypeName(Type type) => VisualBasicObjectFormatter.FormatTypeName(type);
         protected override string CreateExpressionCode(string types, string names, string code) =>
-             $"Public Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
+             $"Option Strict On\nPublic Shared Function CreateExpression() As Expression(Of Func(Of {types}))\nReturn Function({names}) ({code})\nEnd Function";
         protected override int IdentifierKind => (int)Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.IdentifierName;
     }
     public class CSharpJitCompiler : ScriptingJitCompiler

--- a/src/VisualBasic/VisualBasicScriptCompiler.vb
+++ b/src/VisualBasic/VisualBasicScriptCompiler.vb
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting
                     scriptClassName:=submissionTypeName,
                     globalImports:=globalImports,
                     rootNamespace:="",
-                    optionStrict:=OptionStrict.Off,
+                    optionStrict:=OptionStrict.On,
                     optionInfer:=True,
                     optionExplicit:=True,
                     optionCompareText:=False,


### PR DESCRIPTION
Set VB compilation `Option Strict On`. This is to align net5 version to net461, which already does this. See the screenshot below:
Without this, if we assigned `variable1` value `1`, it would have worked, which is not desired!
![error_net461](https://user-images.githubusercontent.com/49864209/114839743-cd717f00-9dde-11eb-8249-b47e02e52ce1.PNG)
