### PR TITLE
Added CSharp designer helper methods to be used in Studio

### DIFF
--- a/src/Test/TestCases.Workflows/DesignerHelperTests.cs
+++ b/src/Test/TestCases.Workflows/DesignerHelperTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.CSharp.Activities;
+using Microsoft.VisualBasic.Activities;
+using Shouldly;
+using System.Activities;
+using Xunit;
+
+namespace TestCases.Workflows
+{
+    public class DesignerHelperTests
+    {
+        [Fact]
+        public void VisualBasicDesigner_CreatesValueProperly()
+        {
+            var sequence = Load(TestXamls.SalaryCalculation);
+
+            var result = VisualBasicDesignerHelper.CreatePrecompiledValue(typeof(string), "MyVar", sequence, out _, out _);
+
+            ((VisualBasicValue<string>)result).ExpressionText.ShouldBe("MyVar");
+        }
+
+        [Fact]
+        public void VisualBasicDesigner_CreatesReferenceProperly()
+        {
+            var sequence = Load(TestXamls.SalaryCalculation);
+
+            var result = VisualBasicDesignerHelper.CreatePrecompiledReference(typeof(string), "MyVar", sequence, out _, out _);
+
+            ((VisualBasicReference<string>)result).ExpressionText.ShouldBe("MyVar");
+        }
+
+        [Fact]
+        public void CSharpDesigner_CreatesValueProperly()
+        {
+            var sequence = Load(TestXamls.SalaryCalculation);
+
+            var result = CSharpDesignerHelper.CreatePrecompiledValue(typeof(string), "MyVar", sequence, out _, out _);
+
+            ((CSharpValue<string>)result).ExpressionText.ShouldBe("MyVar");
+        }
+
+        [Fact]
+        public void CSharpDesigner_CreatesReferenceProperly()
+        {
+            var sequence = Load(TestXamls.SalaryCalculation);
+
+            var result = CSharpDesignerHelper.CreatePrecompiledReference(typeof(string), "MyVar", sequence, out _, out _);
+
+            ((CSharpReference<string>)result).ExpressionText.ShouldBe("MyVar");
+        }
+
+        private Activity Load(TestXamls xaml)
+        {
+            var root = TestHelper.GetActivityFromXamlResource(xaml);
+            WorkflowInspectionServices.CacheMetadata(root);
+            return root.ImplementationChildren[0];
+        }
+    }
+}

--- a/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
+++ b/src/UiPath.Workflow/Microsoft/CSharp/Activities/CSharpDesignerHelper.cs
@@ -40,5 +40,9 @@ namespace Microsoft.CSharp.Activities
         public static Activity CreatePrecompiledReference(Type targetType, string expressionText, IEnumerable<string> namespaces, IEnumerable<string> referencedAssemblies,
             LocationReferenceEnvironment environment, out Type returnType, out SourceExpressionException compileError, out VisualBasicSettings vbSettings) =>
             Impl.CreatePrecompiledReference(targetType, expressionText, namespaces, referencedAssemblies, environment, out returnType, out compileError, out vbSettings);
+        public static Activity CreatePrecompiledValue(Type targetType, string expressionText, Activity parent, out Type returnType, out SourceExpressionException compileError) =>
+            Impl.CreatePrecompiledValue(targetType, expressionText, parent, out returnType, out compileError);
+        public static Activity CreatePrecompiledReference(Type targetType, string expressionText, Activity parent, out Type returnType, out SourceExpressionException compileError) =>
+            Impl.CreatePrecompiledReference(targetType, expressionText, parent, out returnType, out compileError);
     }
 }


### PR DESCRIPTION
The VB ones are used in StudioWeb in regards to view models. Now Studio also will render view models, thus, needing the C# equivalent of these helper methods too.