### PR TITLE
Publish symbols

### DIFF
--- a/.pipelines/release.yaml
+++ b/.pipelines/release.yaml
@@ -23,6 +23,20 @@ jobs:
       pathsToSign: $(Pipeline.Workspace)/$(ArtifactName)/*.nupkg
       runInParallel: true
 
+  - ${{ if eq(parameters.type, 'internal') }}:
+    - task: ExtractFiles@1
+      inputs:
+        archiveFilePatterns: $(Pipeline.Workspace)/$(ArtifactName)/*.snupkg
+        destinationFolder: $(Pipeline.Workspace)/$(ArtifactName)/Symbols
+        cleanDestinationFolder: false
+        overwriteExistingFiles: true
+
+    - task: PublishSymbols@2
+      inputs:
+        symbolsFolder: $(Pipeline.Workspace)/$(ArtifactName)/Symbols
+        searchPattern: '**/*.pdb'
+        symbolServerType: teamServices
+
   - task: NuGetAuthenticate@0
     inputs:
       forceReinstallCredentialProvider: true
@@ -31,11 +45,12 @@ jobs:
     displayName: Push NuGet Packages
     inputs:
       command: push
-      packagesToPush: $(Pipeline.Workspace)/$(ArtifactName)/**/*.nupkg
       ${{ if eq(parameters.type, 'public') }}:
+        packagesToPush: $(Pipeline.Workspace)/$(ArtifactName)/**/*.*nupkg
         nuGetFeedType: external
         publishFeedCredentials: $(NugetFeedServiceConnection)
       ${{ else }}:
+        packagesToPush: $(Pipeline.Workspace)/$(ArtifactName)/**/*.nupkg
         nuGetFeedType: internal
         publishVstsFeed: $(AzureFeedInternal)
     condition: succeeded()

--- a/.pipelines/release.yaml
+++ b/.pipelines/release.yaml
@@ -21,6 +21,8 @@ jobs:
     parameters:
       azureConnectionName: $(AzureConnectionSigning)
       pathsToSign: $(Pipeline.Workspace)/$(ArtifactName)/*.nupkg
+      packagesSignAuthor: true
+      packagesSignRepo: false
       runInParallel: true
 
   - ${{ if eq(parameters.type, 'internal') }}:


### PR DESCRIPTION
Publish symbols to Azure Artifacts Symbol Server and to nuget.org respectively, according to the branch.
❗ also, only author sign the packages as we are currently in talks with the nuget team about a bug we observed when we published test packages that were also repo signed