### PR TITLE
Restore public APIs removed during refactoring

### DIFF
--- a/src/UiPath.Workflow.Runtime/ActivityMetadata.cs
+++ b/src/UiPath.Workflow.Runtime/ActivityMetadata.cs
@@ -114,7 +114,12 @@ public struct ActivityMetadata
         _activity.SetImportedChildrenCollection(importedChildren);
     }
 
-    public void AddImportedChild(Activity importedChild, object origin = null)
+    public void AddImportedChild(Activity importedChild)
+    {
+        AddImportedChild(importedChild, null);
+    }
+
+    public void AddImportedChild(Activity importedChild, object origin)
     {
         ThrowIfDisposed();
         ActivityUtilities.ValidateOrigin(origin, _activity);
@@ -138,7 +143,12 @@ public struct ActivityMetadata
         _activity.SetImportedDelegatesCollection(importedDelegates);
     }
 
-    public void AddImportedDelegate(ActivityDelegate importedDelegate, object origin = null)
+    public void AddImportedDelegate(ActivityDelegate importedDelegate)
+    {
+        AddImportedDelegate(importedDelegate, null);
+    }
+
+    public void AddImportedDelegate(ActivityDelegate importedDelegate, object origin)
     {
         ThrowIfDisposed();
         ActivityUtilities.ValidateOrigin(origin, _activity);
@@ -164,7 +174,12 @@ public struct ActivityMetadata
         _activity.SetVariablesCollection(variables);
     }
 
-    public void AddVariable(Variable variable, object origin = null)
+    public void AddVariable(Variable variable)
+    {
+        AddVariable(variable, null);
+    }
+
+    public void AddVariable(Variable variable, object origin)
     {
         ThrowIfDisposed();
         ActivityUtilities.ValidateOrigin(origin, _activity);

--- a/src/UiPath.Workflow.Runtime/DynamicActivityTypeDescriptor.cs
+++ b/src/UiPath.Workflow.Runtime/DynamicActivityTypeDescriptor.cs
@@ -50,7 +50,7 @@ internal class DynamicActivityTypeDescriptor : ICustomTypeDescriptor
 
     public PropertyDescriptorCollection GetProperties() => GetProperties(null);
 
-    public PropertyDescriptorCollection GetProperties(Attribute[] attributes = null)
+    public PropertyDescriptorCollection GetProperties(Attribute[] attributes)
     {
         PropertyDescriptorCollection result = _cachedProperties;
         if (result != null)

--- a/src/UiPath.Workflow.Runtime/NativeActivityContext.cs
+++ b/src/UiPath.Workflow.Runtime/NativeActivityContext.cs
@@ -164,7 +164,12 @@ public class NativeActivityContext : ActivityContext
         _executor.AbortActivityInstance(activity, reason);
     }
 
-    public void Abort(Exception reason = null)
+    public void Abort()
+    {
+        Abort(null);
+    }
+
+    public void Abort(Exception reason)
     {
         ThrowIfDisposed();
         _executor.AbortWorkflowInstance(reason);


### PR DESCRIPTION
Optional parameters are not the same as overloads for code that was previously compiled against the old version. Causes runtime errors.