### PR TITLE
include UiPath.Workflow in JitCompilerHelper.DefaultReferencedAssemblies

### DIFF
--- a/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
+++ b/src/UiPath.Workflow/Activities/JitCompilerHelper.cs
@@ -35,7 +35,8 @@ internal abstract class JitCompilerHelper
         typeof(CodeTypeDeclaration).Assembly, // System
         typeof(Expression).Assembly, // System.Core
         typeof(Conversions).Assembly, //Microsoft.VisualBasic.Core
-        typeof(Activity).Assembly // System.Activities
+        typeof(Activity).Assembly, // System.Activities,
+        typeof(ActivityBuilder).Assembly // UiPath.Workflow
     };
 
     private static readonly object s_typeReferenceCacheLock = new();


### PR DESCRIPTION
Microsoft.VisualBasic.Activities is a common default namespace and validating workflows that have it imported fails without manually adding an AssemblyReference to UiPath.Workflow in the ReferencesForImplementation xaml collection