### PR TITLE
Enable file nesting in VS2022

### DIFF
--- a/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
+++ b/src/UiPath.Workflow.Runtime/UiPath.Workflow.Runtime.csproj
@@ -23,7 +23,8 @@
     <Using Include="System.Runtime.Serialization" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectCapability Include="DynamicFileNesting" />
+	<ProjectCapability Include="ConfigurableFileNesting" />
+	<ProjectCapability Include="ConfigurableFileNestingFeatureEnabled" />
   </ItemGroup>
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
     <ItemGroup>


### PR DESCRIPTION
File nesting has been missing from VS2022. For some classes that had many nested classes, the code is split into separate files. Explicitly turning on the nesting as detailed in https://github.com/dotnet/project-system/issues/3242#issuecomment-1048684459 puts the nested class files under the class file.

Before:
![Before](https://user-images.githubusercontent.com/2986365/155469068-1f1cc04d-cd29-4782-be2b-12140123292b.png)

After:
![After](https://user-images.githubusercontent.com/2986365/155469260-225f18e1-6bc7-4b86-b825-d41c83eb88c2.png)

